### PR TITLE
Enable separation of concerns

### DIFF
--- a/src/main/kotlin/amaze/Llama.kt
+++ b/src/main/kotlin/amaze/Llama.kt
@@ -29,7 +29,7 @@ class Llama {
 
             val image = getLlamaImage(movePercentageComplete)
 
-            val llamaHeight = if (state == FAllING) {
+            val llamaHeight = if (state == FALLING) {
                 height * SIZE_COEFFICIENT * (1 - movePercentageComplete)
             } else {
                 height * SIZE_COEFFICIENT
@@ -143,13 +143,13 @@ enum class LlamaState(val rotation: Double, val speed: Double) {
     CRASHING(0.0, 1.0),
     SLAUGHTERED(0.0, 0.0),
     ENTERING_PIT(0.0, 1.0),
-    FAllING(0.0, 0.0),
+    FALLING(0.0, 0.0),
     DISAPPEARED(0.0, 0.0),
     VICTORIOUS(0.0, 0.0);
 
     fun getNextState(): LlamaState = when (this) {
-        ENTERING_PIT -> FAllING
-        FAllING -> DISAPPEARED
+        ENTERING_PIT -> FALLING
+        FALLING -> DISAPPEARED
         CRASHING -> SLAUGHTERED
         else -> this
     }

--- a/src/main/kotlin/amaze/Maze.kt
+++ b/src/main/kotlin/amaze/Maze.kt
@@ -70,9 +70,9 @@ class Maze(
             lastMoveTime += MILLIS_PER_MOVE
 
             llamaPosition = llama.finishMove(llamaPosition)
-            if (llama.isDead()) return
+            if (!llama.isReadyForAnotherUserMove()) return
 
-            llama.startMove(controller.getNextMove(this))
+            llama.startUserMove(controller.getNextMove(this))
             val nextPosition = llama.getNextPosition(llamaPosition)
             getEntityAt(nextPosition.column, nextPosition.row).interact(llama)
         }

--- a/src/main/kotlin/amaze/entity/Block.kt
+++ b/src/main/kotlin/amaze/entity/Block.kt
@@ -17,7 +17,7 @@ class Block : Entity() {
     }
 
     override fun interact(llama: Llama) {
-        llama.transitionToState(LlamaState.CRASHED)
+        llama.transitionToState(LlamaState.CRASHING)
     }
 
     private fun randomBlockImage(): BufferedImage {

--- a/src/main/kotlin/amaze/entity/Destination.kt
+++ b/src/main/kotlin/amaze/entity/Destination.kt
@@ -12,6 +12,6 @@ object Destination : Entity() {
     }
 
     override fun interact(llama: Llama) {
-        llama.transitionToState(LlamaState.COMPLETED)
+        llama.transitionToState(LlamaState.VICTORIOUS)
     }
 }


### PR DESCRIPTION
The method `isReadyForAnotherUserMove()` method in conjunction with the `getNextState()` method should make it much easier to manage state and avoid the `Maze` class from needing to know much about the llama states